### PR TITLE
Abbreviation for "Georg"

### DIFF
--- a/abbreviations.rb
+++ b/abbreviations.rb
@@ -173,6 +173,7 @@ module Abbrev
     "gasse" => ["g"],
     "gemeinschaft" => ["gem"],
     "gemeinschafts" => ["gem"],
+    "georg" => ["gg"],
     "groß" => ["gr"],
     "große" => ["gr"],
     "großer" => ["gr"],


### PR DESCRIPTION
I just found another German street abbreviation: "Gg" for "Georg".

Example:
"Gg-Wichtermann-Platz" ([Google search](http://google.com/search?q=gg-wichtermann+platz)) is actually "Georg-Wichtermann-Platz" ([OSM element](http://www.openstreetmap.org/browse/way/38132720)).
